### PR TITLE
Bug fixes

### DIFF
--- a/options.php
+++ b/options.php
@@ -363,7 +363,7 @@ function optionsframework_options()
 
     $options[] = array(
         'name' => __('Cover images url', 'sakurairo'), /*图片库url*/
-        'desc' => sprintf(__('Fill in the manifest path for random picture display, please refer to <a href = "https: //github.com/mashirozx/Sakura/wiki/options">Wiki </a>. If you select webp images above, click <a href = "%s">here</a> to update manifest', 'sakurairo'), rest_url('sakurairo/v1/database/update')), /*填写 manifest 路径，更多信息请参考<a href="https://github.com/mashirozx/Sakura/wiki/options">Wiki</a>,，如果你在上面选择了webp优化，点击<a href = "%s">这里</a>更新 manifest*/
+        'desc' => sprintf(__('Fill in the manifest path for random picture display, please refer to <a href = "https: //github.com/mashirozx/Sakura/wiki/options">Wiki </a>. If you select webp images above, click <a href = "%s">here</a> to update manifest', 'sakurairo'), rest_url('sakura/v1/database/update')), /*填写 manifest 路径，更多信息请参考<a href="https://github.com/mashirozx/Sakura/wiki/options">Wiki</a>,，如果你在上面选择了webp优化，点击<a href = "%s">这里</a>更新 manifest*/
         'id' => 'cover_cdn',
         'std' => 'https://api.btstu.cn/sjbz/api.php?lx=dongman&format=images',
         'type' => 'text');


### PR DESCRIPTION
修复了：在“封面图片库选项”选择“webp优化随机图”，并在封面图片库url输入对应的url，保存后按“点击这里更新 manifest”后显示404报错：
url{"code":"rest_no_route","message":"\u672a\u627e\u5230\u5339\u914dURL\u548c\u8bf7\u6c42\u65b9\u5f0f\u7684\u8def\u7531","data":{"status":404}}